### PR TITLE
Don't zip bzipped files.

### DIFF
--- a/lessons/text-mining-with-extracted-features.md
+++ b/lessons/text-mining-with-extracted-features.md
@@ -1176,12 +1176,11 @@ This command recurses (the `-r` flag) through all the folders on the HTRC server
 It is possible to sync individual files by specifying a full file path. Files are organized in a [PairTree structure](https://wiki.ucop.edu/display/Curation/PairTree), meaning that you can find an exact dataset file from a volume's HathiTrust id. The HTRC Feature Reader has a tools and instructions for [getting the path for a volume](https://github.com/htrc/htrc-feature-reader/blob/master/examples/ID_to_Rsync_Link.ipynb). A list of all file paths is available:
 
 ```bash
-rsync -azv data.analytics.hathitrust.org::features/listing/htrc-ef-all-files.txt .
-
+rsync -av data.analytics.hathitrust.org::features/listing/htrc-ef-all-files.txt .
 ```
 
 Finally, it is possible to download many files from a list. To try, we've put together lists for public-domain [fiction](http://data.analytics.hathitrust.org/genre/fiction_paths.txt), [drama](http://data.analytics.hathitrust.org/genre/drama_paths.txt), and [poetry](http://data.analytics.hathitrust.org/genre/poetry_paths.txt) (Underwood 2014). For example:
 
 ```bash
-rsync -azv --files-from=fiction_paths.txt data.analytics.hathitrust.org::features/ .
+rsync -av --files-from=fiction_paths.txt data.analytics.hathitrust.org::features/ .
 ```

--- a/lessons/text-mining-with-extracted-features.md
+++ b/lessons/text-mining-with-extracted-features.md
@@ -1176,7 +1176,7 @@ This command recurses (the `-r` flag) through all the folders on the HTRC server
 It is possible to sync individual files by specifying a full file path. Files are organized in a [PairTree structure](https://wiki.ucop.edu/display/Curation/PairTree), meaning that you can find an exact dataset file from a volume's HathiTrust id. The HTRC Feature Reader has a tools and instructions for [getting the path for a volume](https://github.com/htrc/htrc-feature-reader/blob/master/examples/ID_to_Rsync_Link.ipynb). A list of all file paths is available:
 
 ```bash
-rsync -av data.analytics.hathitrust.org::features/listing/htrc-ef-all-files.txt .
+rsync -azv data.analytics.hathitrust.org::features/listing/htrc-ef-all-files.txt .
 ```
 
 Finally, it is possible to download many files from a list. To try, we've put together lists for public-domain [fiction](http://data.analytics.hathitrust.org/genre/fiction_paths.txt), [drama](http://data.analytics.hathitrust.org/genre/drama_paths.txt), and [poetry](http://data.analytics.hathitrust.org/genre/poetry_paths.txt) (Underwood 2014). For example:


### PR DESCRIPTION
These rsync commands include a flag to zip files for transfer that are already bzipped. That's unlikely to be useful and likely to be harmful, right?

